### PR TITLE
Allow configuring npm without git deploy key, for read-only access

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -108,11 +108,11 @@ ${UNSAFE_PERM}
       const mockExec = mocked(exec)
       expect(mockExec.mock.calls.length).toEqual(6)
 
-      expect(mockExec.mock.calls[0][0]).toEqual('ssh-keyscan')
-      expect(mockExec.mock.calls[1]).toEqual([
+      expect(mockExec.mock.calls[0]).toEqual([
         'git',
         ['update-index', '--assume-unchanged', '.npmrc']
       ])
+      expect(mockExec.mock.calls[1][0]).toEqual('ssh-keyscan')
       expect(mockExec.mock.calls[2]).toEqual([
         'git',
         ['config', 'user.email', email]
@@ -165,11 +165,11 @@ ${UNSAFE_PERM}
       const mockExec = mocked(exec)
       expect(mockExec.mock.calls.length).toEqual(6)
 
-      expect(mockExec.mock.calls[0][0]).toEqual('ssh-keyscan')
-      expect(mockExec.mock.calls[1]).toEqual([
+      expect(mockExec.mock.calls[0]).toEqual([
         'git',
         ['update-index', '--assume-unchanged', '.npmrc']
       ])
+      expect(mockExec.mock.calls[1][0]).toEqual('ssh-keyscan')
       expect(mockExec.mock.calls[2]).toEqual([
         'git',
         ['config', 'user.email', email]

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -3,7 +3,7 @@ import {exec} from '@actions/exec'
 import {promises as fs} from 'fs'
 import * as fssync from 'fs'
 import * as path from 'path'
-import {mocked} from 'ts-jest/utils'
+import {mocked} from 'jest-mock'
 
 import {
   UNSAFE_PERM,
@@ -41,7 +41,7 @@ beforeEach(() => {
 afterEach(() => {
   process.chdir(originalDirectory)
   process.env = OLD_ENV
-  fssync.rmdirSync(runnerTempDir as string, {recursive: true})
+  fssync.rmSync(runnerTempDir as string, {recursive: true})
   runnerTempDir = null
 })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run(): Promise<void> {
     core.saveState('isPost', post)
     const email: string = core.getInput('email')
     const username: string = core.getInput('username')
-    const deployKey: string = getEnv('GIT_DEPLOY_KEY')
+    const deployKey: string | null = getEnv('GIT_DEPLOY_KEY') || null
     const token: string | null = process.env['AUTH_TOKEN_STRING'] || null
 
     if (!post) {


### PR DESCRIPTION
In order to inject read-only credentials for npm in github actions, we don't want to configure a deploy SSH key at the same time.

Allow configuring the action without an SSH key to inject only an npm token