### PR TITLE
VULCAN-2751/Support non-existing .npmrc

### DIFF
--- a/.github/scripts/test_missing_npmrc_post.sh
+++ b/.github/scripts/test_missing_npmrc_post.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -f .npmrc ]; then
+  echo "The npmrc file should not exist!"
+  exit 1
+fi

--- a/.github/scripts/test_post.sh
+++ b/.github/scripts/test_post.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+if [ ! -f .npmrc ]; then
+  echo "The npmrc file should exist!"
+  exit 1
+fi

--- a/.github/templates/jobs/test.erb
+++ b/.github/templates/jobs/test.erb
@@ -4,39 +4,35 @@ test:
     EMAIL_INPUT: test@example.com
     USERNAME_INPUT: example-test
   steps:
-  - uses: actions/checkout@v3
-  - name: Set Node.js 16.x
-    uses: actions/setup-node@v3
+  @import ../steps/test_prepare
+  - uses: webiny/action-post-run@3.0.0
     with:
-      node-version: 16.x
-  - name: "Build action for test"
-    run: |
-      npm install
-      npm run build
-      npm run package
-      git clean -fXd
-  - name: Test executing the action
-    uses: ./
-    env:
-      GIT_DEPLOY_KEY: not-a-real-key
-      AUTH_TOKEN_STRING: definitely-real-token
-    with:
-      email: ${{ env.EMAIL_INPUT }}
-      username: ${{ env.USERNAME_INPUT }}
+      run: .github/scripts/test_post.sh
+  @import ../steps/test_execute
+
+test-missing-npmrc:
+  runs-on: <%= ubuntu_version %>
+  env:
+    EMAIL_INPUT: test@example.com
+    USERNAME_INPUT: example-test
+  steps:
+  @import ../steps/test_prepare
   - run: |
-      set -u
-      cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa"
-      echo
-      git config user.name
-      git config user.email
-      git remote get-url origin
-      git config core.sshCommand
-      grep '^github\.com' "$RUNNER_TEMP/setup-npm-publish-action/known_hosts"
+      git config --global user.email "fake@fake.com"
+      git config --global user.name "Testing"
+      git rm .npmrc
+      git commit -m "mark removed npmrc file"
+  - uses: webiny/action-post-run@3.0.0
+    with:
+      run: .github/scripts/test_missing_npmrc_post.sh
+  @import ../steps/test_execute
 
-      [[ "$(cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa")" == "not-a-real-key" ]]
-      [[ "$(git config user.name)" == "${{ env.USERNAME_INPUT }}" ]]
-      [[ "$(git config user.email)" == "${{ env.EMAIL_INPUT }}" ]]
-      [[ "$(git remote get-url origin)" == "git@github.com:$GITHUB_REPOSITORY.git" ]]
-
-      # Just check that it is altered from default
-      [[ "$(git config core.sshCommand)" == *UserKnownHostsFile* ]]
+test-all:
+  needs:
+    - test
+    - test-missing-npmrc
+  runs-on: <%= ubuntu_version %>
+  steps:
+    - run: |
+        echo "Ok"
+      shell: bash

--- a/.github/templates/pull_request.yml.erb
+++ b/.github/templates/pull_request.yml.erb
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: <%= ubuntu_version %>
     name: "Build and release action"
-    needs: [build, test]
+    needs: [build, test-all]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/templates/release.yml.erb
+++ b/.github/templates/release.yml.erb
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: <%= ubuntu_version %>
     name: "Build and release action"
-    needs: [build, test]
+    needs: [build, test-all]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/templates/steps/test_execute.erb
+++ b/.github/templates/steps/test_execute.erb
@@ -1,0 +1,25 @@
+- name: Test executing the action
+  uses: ./
+  env:
+    GIT_DEPLOY_KEY: not-a-real-key
+    AUTH_TOKEN_STRING: definitely-real-token
+  with:
+    email: ${{ env.EMAIL_INPUT }}
+    username: ${{ env.USERNAME_INPUT }}
+- run: |
+    set -u
+    cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa"
+    echo
+    git config user.name
+    git config user.email
+    git remote get-url origin
+    git config core.sshCommand
+    grep '^github\.com' "$RUNNER_TEMP/setup-npm-publish-action/known_hosts"
+    
+    [[ "$(cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa")" == "not-a-real-key" ]]
+    [[ "$(git config user.name)" == "${{ env.USERNAME_INPUT }}" ]]
+    [[ "$(git config user.email)" == "${{ env.EMAIL_INPUT }}" ]]
+    [[ "$(git remote get-url origin)" == "git@github.com:$GITHUB_REPOSITORY.git" ]]
+    
+    # Just check that it is altered from default
+    [[ "$(git config core.sshCommand)" == *UserKnownHostsFile* ]]

--- a/.github/templates/steps/test_prepare.erb
+++ b/.github/templates/steps/test_prepare.erb
@@ -1,0 +1,11 @@
+- uses: actions/checkout@v3
+- name: Set Node.js 16.x
+  uses: actions/setup-node@v3
+  with:
+    node-version: 16.x
+- name: "Build action for test"
+  run: |
+    npm install
+    npm run build
+    npm run package
+    git clean -fXd

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -56,6 +56,9 @@ jobs:
         npm run build
         npm run package
         git clean -fXd
+    - uses: webiny/action-post-run@3.0.0
+      with:
+        run: .github/scripts/test_post.sh
     - name: Test executing the action
       uses: ./
       env:
@@ -82,10 +85,71 @@ jobs:
         # Just check that it is altered from default
         [[ "$(git config core.sshCommand)" == *UserKnownHostsFile* ]]
 
+  test-missing-npmrc:
+    runs-on: ubuntu-20.04
+    env:
+      EMAIL_INPUT: test@example.com
+      USERNAME_INPUT: example-test
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+    - name: "Build action for test"
+      run: |
+        npm install
+        npm run build
+        npm run package
+        git clean -fXd
+    - run: |
+        git config --global user.email "fake@fake.com"
+        git config --global user.name "Testing"
+        git rm .npmrc
+        git commit -m "mark removed npmrc file"
+    - uses: webiny/action-post-run@3.0.0
+      with:
+        run: .github/scripts/test_missing_npmrc_post.sh
+    - name: Test executing the action
+      uses: ./
+      env:
+        GIT_DEPLOY_KEY: not-a-real-key
+        AUTH_TOKEN_STRING: definitely-real-token
+      with:
+        email: ${{ env.EMAIL_INPUT }}
+        username: ${{ env.USERNAME_INPUT }}
+    - run: |
+        set -u
+        cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa"
+        echo
+        git config user.name
+        git config user.email
+        git remote get-url origin
+        git config core.sshCommand
+        grep '^github\.com' "$RUNNER_TEMP/setup-npm-publish-action/known_hosts"
+
+        [[ "$(cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa")" == "not-a-real-key" ]]
+        [[ "$(git config user.name)" == "${{ env.USERNAME_INPUT }}" ]]
+        [[ "$(git config user.email)" == "${{ env.EMAIL_INPUT }}" ]]
+        [[ "$(git remote get-url origin)" == "git@github.com:$GITHUB_REPOSITORY.git" ]]
+
+        # Just check that it is altered from default
+        [[ "$(git config core.sshCommand)" == *UserKnownHostsFile* ]]
+
+  test-all:
+    needs:
+      - test
+      - test-missing-npmrc
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          echo "Ok"
+        shell: bash
+
   release:
     runs-on: ubuntu-20.04
     name: "Build and release action"
-    needs: [build, test]
+    needs: [build, test-all]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -56,6 +56,9 @@ jobs:
         npm run build
         npm run package
         git clean -fXd
+    - uses: webiny/action-post-run@3.0.0
+      with:
+        run: .github/scripts/test_post.sh
     - name: Test executing the action
       uses: ./
       env:
@@ -82,10 +85,71 @@ jobs:
         # Just check that it is altered from default
         [[ "$(git config core.sshCommand)" == *UserKnownHostsFile* ]]
 
+  test-missing-npmrc:
+    runs-on: ubuntu-20.04
+    env:
+      EMAIL_INPUT: test@example.com
+      USERNAME_INPUT: example-test
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+    - name: "Build action for test"
+      run: |
+        npm install
+        npm run build
+        npm run package
+        git clean -fXd
+    - run: |
+        git config --global user.email "fake@fake.com"
+        git config --global user.name "Testing"
+        git rm .npmrc
+        git commit -m "mark removed npmrc file"
+    - uses: webiny/action-post-run@3.0.0
+      with:
+        run: .github/scripts/test_missing_npmrc_post.sh
+    - name: Test executing the action
+      uses: ./
+      env:
+        GIT_DEPLOY_KEY: not-a-real-key
+        AUTH_TOKEN_STRING: definitely-real-token
+      with:
+        email: ${{ env.EMAIL_INPUT }}
+        username: ${{ env.USERNAME_INPUT }}
+    - run: |
+        set -u
+        cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa"
+        echo
+        git config user.name
+        git config user.email
+        git remote get-url origin
+        git config core.sshCommand
+        grep '^github\.com' "$RUNNER_TEMP/setup-npm-publish-action/known_hosts"
+
+        [[ "$(cat "$RUNNER_TEMP/setup-npm-publish-action/id_rsa")" == "not-a-real-key" ]]
+        [[ "$(git config user.name)" == "${{ env.USERNAME_INPUT }}" ]]
+        [[ "$(git config user.email)" == "${{ env.EMAIL_INPUT }}" ]]
+        [[ "$(git remote get-url origin)" == "git@github.com:$GITHUB_REPOSITORY.git" ]]
+
+        # Just check that it is altered from default
+        [[ "$(git config core.sshCommand)" == *UserKnownHostsFile* ]]
+
+  test-all:
+    needs:
+      - test
+      - test-missing-npmrc
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          echo "Ok"
+        shell: bash
+
   release:
     runs-on: ubuntu-20.04
     name: "Build and release action"
-    needs: [build, test]
+    needs: [build, test-all]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependency directory
 node_modules
+.idea
 
 # Rest pulled from https://github.com/github/gitignore/blob/master/Node.gitignore
 # Logs

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import {cleanupNpmPublish, setupNpmPublish} from './setup-npm-publish'
+import {constants, promises as fs} from 'fs'
 
 function isPost(): boolean {
   // Will be false if the environment variable doesn't exist; true if it does.
@@ -16,9 +17,28 @@ async function run(): Promise<void> {
     const token: string | null = process.env['AUTH_TOKEN_STRING'] || null
 
     if (!post) {
-      await setupNpmPublish(email, username, deployKey, token)
+      let npmrcExists = false
+      try {
+        await fs.access('.npmrc', constants.F_OK)
+        npmrcExists = true
+      } catch {
+        /* NOOP */
+      }
+
+      await setupNpmPublish(email, username, deployKey, token, npmrcExists)
     } else {
-      await cleanupNpmPublish()
+      let npmrcInGitExcluded = false
+      try {
+        await fs.access('.git/info/exclude', constants.F_OK)
+        npmrcInGitExcluded =
+          (await fs.readFile('.git/info/exclude', 'utf-8')).match(
+            /^\.npmrc$/m
+          ) != null
+      } catch {
+        /* NOOP */
+      }
+
+      await cleanupNpmPublish(npmrcInGitExcluded)
     }
   } catch (error) {
     core.setFailed((error as Error).message)


### PR DESCRIPTION
This PR allows this action to function also when an `.npmrc` file does not exist in the original repository.

The flow now will create/inject a new `.npmrc` file and mark it as excluded (for the duration of the action) in the `.git/info/exclude` file.

If the `.npmrc` file does not exist at the beginning of the pipeline, it will not exist at the end of it either.