### PR TITLE
[VULCAN-2855] Add npmrcPath support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Action to setup npm and git for npm publish. It appends authentication tokens to
 |------------|-----------|-----------------------------|
 | email      | no        | Email to use with git       |
 | username   | no        | Username to use with git    |
-| npmrc_path | no        | Relative path to npmrc file |
+| npmrc-path | no        | Relative path to npmrc file |
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Action to setup npm and git for npm publish. It appends authentication tokens to
 
 ## Inputs
 
-| Input    | Required  | Description              |
-|----------|-----------|--------------------------|
-| email    | no        | Email to use with git    |
-| username | no        | Username to use with git |
+| Input      | Required  | Description                 |
+|------------|-----------|-----------------------------|
+| email      | no        | Email to use with git       |
+| username   | no        | Username to use with git    |
+| npmrc_path | no        | Relative path to npmrc file |
 
 ## Environment variables
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Username to use with git'
     required: false
     default: 'Github Action'
-  npmrc_path:
+  npmrc-path:
     description: 'Relative path to npmrc file'
     required: false
     default: '.npmrc'

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Username to use with git'
     required: false
     default: 'Github Action'
+  npmrc_path:
+    description: 'Relative path to npmrc file'
+    required: false
+    default: '.npmrc'
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function run(): Promise<void> {
     core.saveState('isPost', post)
     const email: string = core.getInput('email')
     const username: string = core.getInput('username')
-    const npmrcPath: string = core.getInput('npmrc_path')
+    const npmrcPath: string = core.getInput('npmrc-path')
     const deployKey: string | null = process.env['GIT_DEPLOY_KEY'] || null
     const token: string | null = process.env['AUTH_TOKEN_STRING'] || null
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ async function run(): Promise<void> {
       let npmrcExists = false
       try {
         await fs.access(npmrcPath, constants.F_OK)
+        core.info(`${npmrcPath} file exists in the repo`)
         npmrcExists = true
       } catch {
         /* NOOP */

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,9 +38,10 @@ async function run(): Promise<void> {
       let npmrcInGitExcluded = false
       try {
         await fs.access('.git/info/exclude', constants.F_OK)
+        const npmrcPathRegex = npmrcPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
         npmrcInGitExcluded =
           (await fs.readFile('.git/info/exclude', 'utf-8')).match(
-            new RegExp(`^${npmrcPath}$`, 'm')
+            new RegExp(`^${npmrcPathRegex}$`, 'm')
           ) != null
       } catch {
         /* NOOP */

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,14 @@ async function run(): Promise<void> {
         /* NOOP */
       }
 
-      await setupNpmPublish(email, username, deployKey, token, npmrcPath, npmrcExists)
+      await setupNpmPublish(
+        email,
+        username,
+        deployKey,
+        token,
+        npmrcPath,
+        npmrcExists
+      )
     } else {
       let npmrcInGitExcluded = false
       try {

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -43,7 +43,7 @@ export async function setupNpmPublish(
   deployKey: string | null,
   token: string | null,
   npmrcPath: string,
-  npmrcDidExist: boolean,
+  npmrcDidExist: boolean
 ): Promise<void> {
   const keyPath = getSshPath('id_rsa')
   const knownHostsPath = getSshPath('known_hosts')
@@ -99,7 +99,7 @@ export async function setupNpmPublish(
 
 export async function cleanupNpmPublish(
   npmrcPath: string,
-  npmrcInGitExcluded: boolean,
+  npmrcInGitExcluded: boolean
 ): Promise<void> {
   const gitDeploySkipped = core.getState('skipGitDeployKey') === 'true'
 

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -51,17 +51,17 @@ export async function setupNpmPublish(
   await fs.mkdir(sshDir, {recursive: true})
 
   if (token) {
-    core.info(`Writing token file to .npmrc`)
+    core.info(`Writing token file to ${npmrcPath}`)
     await fs.writeFile(npmrcPath, token)
   }
   // Is this still needed?
   await fs.appendFile(npmrcPath, `\n${UNSAFE_PERM}\n`)
 
-  core.info('Marking .npmrc as unmodified to avoid committing the keys')
+  core.info(`Marking ${npmrcPath} as unmodified to avoid committing the keys`)
   if (npmrcDidExist) {
     await exec.exec('git', ['update-index', '--assume-unchanged', npmrcPath])
   } else {
-    core.info('.npmrc did not exist before running the action')
+    core.info(`${npmrcPath} did not exist before running the action`)
     // Mark it as excluded locally
     try {
       await fs.access('.git/info/exclude', constants.F_OK)


### PR DESCRIPTION
We have some repos with non-root .npmrc file location. In order to inject auth tokens into files in such repos we need ability to override path to `.npmrc` file