### PR TITLE
Use npm config set to merge config into .npmrc instead of overwriting it

### DIFF
--- a/.github/templates/steps/test_execute.erb
+++ b/.github/templates/steps/test_execute.erb
@@ -2,7 +2,8 @@
   uses: ./
   env:
     GIT_DEPLOY_KEY: not-a-real-key
-    AUTH_TOKEN_STRING: definitely-real-token
+    AUTH_TOKEN_STRING: |
+      email = devops@smartly.io
   with:
     email: ${{ env.EMAIL_INPUT }}
     username: ${{ env.USERNAME_INPUT }}

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -63,7 +63,8 @@ jobs:
       uses: ./
       env:
         GIT_DEPLOY_KEY: not-a-real-key
-        AUTH_TOKEN_STRING: definitely-real-token
+        AUTH_TOKEN_STRING: |
+          email = devops@smartly.io
       with:
         email: ${{ env.EMAIL_INPUT }}
         username: ${{ env.USERNAME_INPUT }}
@@ -109,7 +110,8 @@ jobs:
       uses: ./
       env:
         GIT_DEPLOY_KEY: not-a-real-key
-        AUTH_TOKEN_STRING: definitely-real-token
+        AUTH_TOKEN_STRING: |
+          email = devops@smartly.io
       with:
         email: ${{ env.EMAIL_INPUT }}
         username: ${{ env.USERNAME_INPUT }}
@@ -161,7 +163,8 @@ jobs:
       uses: ./
       env:
         GIT_DEPLOY_KEY: not-a-real-key
-        AUTH_TOKEN_STRING: definitely-real-token
+        AUTH_TOKEN_STRING: |
+          email = devops@smartly.io
       with:
         email: ${{ env.EMAIL_INPUT }}
         username: ${{ env.USERNAME_INPUT }}

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -63,7 +63,8 @@ jobs:
       uses: ./
       env:
         GIT_DEPLOY_KEY: not-a-real-key
-        AUTH_TOKEN_STRING: definitely-real-token
+        AUTH_TOKEN_STRING: |
+          email = devops@smartly.io
       with:
         email: ${{ env.EMAIL_INPUT }}
         username: ${{ env.USERNAME_INPUT }}
@@ -109,7 +110,8 @@ jobs:
       uses: ./
       env:
         GIT_DEPLOY_KEY: not-a-real-key
-        AUTH_TOKEN_STRING: definitely-real-token
+        AUTH_TOKEN_STRING: |
+          email = devops@smartly.io
       with:
         email: ${{ env.EMAIL_INPUT }}
         username: ${{ env.USERNAME_INPUT }}
@@ -161,7 +163,8 @@ jobs:
       uses: ./
       env:
         GIT_DEPLOY_KEY: not-a-real-key
-        AUTH_TOKEN_STRING: definitely-real-token
+        AUTH_TOKEN_STRING: |
+          email = devops@smartly.io
       with:
         email: ${{ env.EMAIL_INPUT }}
         username: ${{ env.USERNAME_INPUT }}

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -28,8 +28,6 @@ jest.mock('@actions/exec', () => ({
 
 const {exec: actualExec} = jest.requireActual('@actions/exec')
 
-const UNSAFE_PERM = /unsafe-perm\s*=\s*true/
-
 function matchNpmrcOptions(
   values: Record<string, string>,
   npmrcContent: string

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -30,17 +30,27 @@ const {exec: actualExec} = jest.requireActual('@actions/exec')
 
 const UNSAFE_PERM = /unsafe-perm\s*=\s*true/
 
-function matchNpmrcOptions (values: Record<string, string>, npmrcContent: string): void {
+function matchNpmrcOptions(
+  values: Record<string, string>,
+  npmrcContent: string
+): void {
   for (const key in values) {
     const value = values[key]
-    expect(npmrcContent.toString()).toMatch(new RegExp(`^${key}\\s*=\\s*${value}$`, 'm'))
+    expect(npmrcContent.toString()).toMatch(
+      new RegExp(`^${key}\\s*=\\s*${value}$`, 'm')
+    )
   }
 }
 
-function negativeMatchNpmrcOptions (values: Record<string, string>, npmrcContent: string): void {
+function negativeMatchNpmrcOptions(
+  values: Record<string, string>,
+  npmrcContent: string
+): void {
   for (const key in values) {
     const value = values[key]
-    expect(npmrcContent.toString()).not.toMatch(new RegExp(`^${key}\\s*=\\s*${value}$`, 'm'))
+    expect(npmrcContent.toString()).not.toMatch(
+      new RegExp(`^${key}\\s*=\\s*${value}$`, 'm')
+    )
   }
 }
 
@@ -83,7 +93,9 @@ describe('test npm-setup-publish', () => {
   describe('git configutation', () => {
     test('get ssh path', () => {
       const filePath = getSshPath('id_rsa')
-      expect(filePath).toEqual(`${runnerTempDir}/setup-npm-publish-action/id_rsa`)
+      expect(filePath).toEqual(
+        `${runnerTempDir}/setup-npm-publish-action/id_rsa`
+      )
     })
 
     test('ssh-keyscan', async () => {
@@ -125,7 +137,7 @@ describe('test npm-setup-publish', () => {
       const options: Record<string, string> = {
         'always-auth': 'true',
         'unsafe-perm': 'true'
-      };
+      }
 
       matchNpmrcOptions(options, npmrcContent)
     })
@@ -148,7 +160,7 @@ describe('test npm-setup-publish', () => {
       const options: Record<string, string> = {
         'always-auth': 'true',
         'unsafe-perm': 'true'
-      };
+      }
 
       matchNpmrcOptions(options, npmrcContent)
     })
@@ -172,7 +184,7 @@ describe('test npm-setup-publish', () => {
       const options: Record<string, string> = {
         'always-auth': 'true',
         'unsafe-perm': 'true'
-      };
+      }
 
       matchNpmrcOptions(options, npmrcContent)
     })
@@ -195,13 +207,13 @@ describe('test npm-setup-publish', () => {
       const npmrcContent = (await fs.readFile(npmrcPath)).toString()
       const expectedValues: Record<string, string> = {
         'unsafe-perm': 'true'
-      };
+      }
 
       matchNpmrcOptions(expectedValues, npmrcContent)
 
       const missingValues: Record<string, string> = {
         'always-auth': 'true'
-      };
+      }
 
       negativeMatchNpmrcOptions(missingValues, npmrcContent)
     })
@@ -220,7 +232,14 @@ describe('test npm-setup-publish', () => {
       const deployKey = 'definitely an ssh key'
       const newNpmrc = 'always-auth = true'
 
-      await setupNpmPublish(email, username, deployKey, newNpmrc, '.npmrc', true)
+      await setupNpmPublish(
+        email,
+        username,
+        deployKey,
+        newNpmrc,
+        '.npmrc',
+        true
+      )
 
       const sshKeyData = await fs.readFile(
         path.join(runnerTempDir as string, 'setup-npm-publish-action', 'id_rsa')
@@ -283,7 +302,14 @@ describe('test npm-setup-publish', () => {
       const deployKey = 'definitely an ssh key'
       const newNpmrc = null
 
-      await setupNpmPublish(email, username, deployKey, newNpmrc, '.npmrc', true)
+      await setupNpmPublish(
+        email,
+        username,
+        deployKey,
+        newNpmrc,
+        '.npmrc',
+        true
+      )
 
       const sshKeyData = await fs.readFile(
         path.join(runnerTempDir as string, 'setup-npm-publish-action', 'id_rsa')
@@ -341,7 +367,14 @@ describe('test npm-setup-publish', () => {
       const deployKey = null
       const newNpmrc = 'always-auth = true'
 
-      await setupNpmPublish(email, username, deployKey, newNpmrc, '.npmrc', true)
+      await setupNpmPublish(
+        email,
+        username,
+        deployKey,
+        newNpmrc,
+        '.npmrc',
+        true
+      )
 
       const mockExec = mocked(exec)
       expect(mockExec.mock.calls.length).toEqual(3)
@@ -372,13 +405,27 @@ describe('test npm-setup-publish', () => {
       const deployKey = null
       const newNpmrc = 'email = somename@example.com'
 
-      await setupNpmPublish(email, username, deployKey, newNpmrc, '.npmrc', false)
+      await setupNpmPublish(
+        email,
+        username,
+        deployKey,
+        newNpmrc,
+        '.npmrc',
+        false
+      )
 
       const mockExec = mocked(exec)
       expect(mockExec.mock.calls.length).toEqual(2)
       expect(mockExec.mock.calls[0]).toEqual([
         'npm',
-        ['config', 'set', '--location', 'project', 'email', 'somename@example.com'],
+        [
+          'config',
+          'set',
+          '--location',
+          'project',
+          'email',
+          'somename@example.com'
+        ],
         expect.objectContaining({cwd: repository})
       ])
       expect(mockExec.mock.calls[1]).toEqual([
@@ -403,7 +450,14 @@ describe('test npm-setup-publish', () => {
       const deployKey = 'definitely an ssh key'
       const newNpmrc = 'always-auth = true'
 
-      await setupNpmPublish(email, username, deployKey, newNpmrc, npmrcPath, true)
+      await setupNpmPublish(
+        email,
+        username,
+        deployKey,
+        newNpmrc,
+        npmrcPath,
+        true
+      )
 
       const sshKeyData = await fs.readFile(
         path.join(runnerTempDir as string, 'setup-npm-publish-action', 'id_rsa')

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -133,8 +133,7 @@ describe('test npm-setup-publish', () => {
 
       const npmrcContent = (await fs.readFile(npmrcPath)).toString()
       const options: Record<string, string> = {
-        registry: 'https://artifactor.ee/registry',
-        'unsafe-perm': 'true'
+        registry: 'https://artifactor.ee/registry'
       }
 
       matchNpmrcOptions(options, npmrcContent)
@@ -156,8 +155,7 @@ describe('test npm-setup-publish', () => {
 
       const npmrcContent = (await fs.readFile(npmrcPath)).toString()
       const options: Record<string, string> = {
-        registry: 'https://artifactor.ee/registry',
-        'unsafe-perm': 'true'
+        registry: 'https://artifactor.ee/registry'
       }
 
       matchNpmrcOptions(options, npmrcContent)
@@ -180,40 +178,10 @@ describe('test npm-setup-publish', () => {
 
       const npmrcContent = (await fs.readFile(npmrcPath)).toString()
       const options: Record<string, string> = {
-        registry: 'https://artifactor.ee/registry',
-        'unsafe-perm': 'true'
-      }
-
-      matchNpmrcOptions(options, npmrcContent)
-    })
-
-    test('Updates npmrc unsafe-perm even if no config given', async () => {
-      const repository = path.join(runnerTempDir as string, 'repo')
-      const npmrcPath = path.join(repository, '.npmrc')
-      await fs.mkdir(repository, {recursive: true})
-      process.chdir(repository)
-      await fs.writeFile(npmrcPath, '')
-      await fs.writeFile('package.json', '{}')
-
-      const mockExec = mocked(exec)
-      mockExec.mockImplementation(async (cmd, args, options) => {
-        return await actualExec(cmd, args, options)
-      })
-
-      await updateNpmrc(npmrcPath, null)
-
-      const npmrcContent = (await fs.readFile(npmrcPath)).toString()
-      const expectedValues: Record<string, string> = {
-        'unsafe-perm': 'true'
-      }
-
-      matchNpmrcOptions(expectedValues, npmrcContent)
-
-      const missingValues: Record<string, string> = {
         registry: 'https://artifactor.ee/registry'
       }
 
-      negativeMatchNpmrcOptions(missingValues, npmrcContent)
+      matchNpmrcOptions(options, npmrcContent)
     })
 
     test('rejects always-auth', async () => {
@@ -234,12 +202,7 @@ describe('test npm-setup-publish', () => {
         'always-auth=true\n//repo/:always-auth=true\n'
       )
 
-      const npmrcContent = (await fs.readFile(npmrcPath)).toString()
-      const options: Record<string, string> = {
-        'unsafe-perm': 'true'
-      }
-
-      matchNpmrcOptions(options, npmrcContent)
+      expect(mockExec.mock.calls.length).toEqual(0)
 
       const mockWarning = mocked(warning)
       expect(mockWarning.mock.calls.length).toEqual(2)
@@ -281,7 +244,7 @@ describe('test npm-setup-publish', () => {
       expect(sshKeyData.toString()).toEqual(`${deployKey}\n`)
 
       const mockExec = mocked(exec)
-      expect(mockExec.mock.calls.length).toEqual(8)
+      expect(mockExec.mock.calls.length).toEqual(7)
 
       expect(mockExec.mock.calls[0]).toEqual([
         'npm',
@@ -296,24 +259,19 @@ describe('test npm-setup-publish', () => {
         expect.objectContaining({cwd: repository})
       ])
       expect(mockExec.mock.calls[1]).toEqual([
-        'npm',
-        ['config', 'set', '--location', 'project', 'unsafe-perm', 'true'],
-        expect.objectContaining({cwd: repository})
-      ])
-      expect(mockExec.mock.calls[2]).toEqual([
         'git',
         ['update-index', '--assume-unchanged', '.npmrc']
       ])
-      expect(mockExec.mock.calls[3][0]).toEqual('ssh-keyscan')
-      expect(mockExec.mock.calls[4]).toEqual([
+      expect(mockExec.mock.calls[2][0]).toEqual('ssh-keyscan')
+      expect(mockExec.mock.calls[3]).toEqual([
         'git',
         ['config', 'user.email', email]
       ])
-      expect(mockExec.mock.calls[5]).toEqual([
+      expect(mockExec.mock.calls[4]).toEqual([
         'git',
         ['config', 'user.name', username]
       ])
-      expect(mockExec.mock.calls[6]).toEqual([
+      expect(mockExec.mock.calls[5]).toEqual([
         'git',
         [
           'config',
@@ -321,7 +279,7 @@ describe('test npm-setup-publish', () => {
           expect.stringContaining('UserKnownHostsFile')
         ]
       ])
-      expect(mockExec.mock.calls[7]).toEqual([
+      expect(mockExec.mock.calls[6]).toEqual([
         'git',
         [
           'remote',
@@ -358,27 +316,22 @@ describe('test npm-setup-publish', () => {
       expect(sshKeyData.toString()).toEqual(`${deployKey}\n`)
 
       const mockExec = mocked(exec)
-      expect(mockExec.mock.calls.length).toEqual(7)
+      expect(mockExec.mock.calls.length).toEqual(6)
 
       expect(mockExec.mock.calls[0]).toEqual([
-        'npm',
-        ['config', 'set', '--location', 'project', 'unsafe-perm', 'true'],
-        expect.objectContaining({cwd: repository})
-      ])
-      expect(mockExec.mock.calls[1]).toEqual([
         'git',
         ['update-index', '--assume-unchanged', '.npmrc']
       ])
-      expect(mockExec.mock.calls[2][0]).toEqual('ssh-keyscan')
-      expect(mockExec.mock.calls[3]).toEqual([
+      expect(mockExec.mock.calls[1][0]).toEqual('ssh-keyscan')
+      expect(mockExec.mock.calls[2]).toEqual([
         'git',
         ['config', 'user.email', email]
       ])
-      expect(mockExec.mock.calls[4]).toEqual([
+      expect(mockExec.mock.calls[3]).toEqual([
         'git',
         ['config', 'user.name', username]
       ])
-      expect(mockExec.mock.calls[5]).toEqual([
+      expect(mockExec.mock.calls[4]).toEqual([
         'git',
         [
           'config',
@@ -386,7 +339,7 @@ describe('test npm-setup-publish', () => {
           expect.stringContaining('UserKnownHostsFile')
         ]
       ])
-      expect(mockExec.mock.calls[6]).toEqual([
+      expect(mockExec.mock.calls[5]).toEqual([
         'git',
         [
           'remote',
@@ -418,7 +371,7 @@ describe('test npm-setup-publish', () => {
       )
 
       const mockExec = mocked(exec)
-      expect(mockExec.mock.calls.length).toEqual(3)
+      expect(mockExec.mock.calls.length).toEqual(2)
 
       expect(mockExec.mock.calls[0]).toEqual([
         'npm',
@@ -433,11 +386,6 @@ describe('test npm-setup-publish', () => {
         expect.objectContaining({cwd: repository})
       ])
       expect(mockExec.mock.calls[1]).toEqual([
-        'npm',
-        ['config', 'set', '--location', 'project', 'unsafe-perm', 'true'],
-        expect.objectContaining({cwd: repository})
-      ])
-      expect(mockExec.mock.calls[2]).toEqual([
         'git',
         ['update-index', '--assume-unchanged', '.npmrc']
       ])
@@ -463,7 +411,7 @@ describe('test npm-setup-publish', () => {
       )
 
       const mockExec = mocked(exec)
-      expect(mockExec.mock.calls.length).toEqual(2)
+      expect(mockExec.mock.calls.length).toEqual(1)
       expect(mockExec.mock.calls[0]).toEqual([
         'npm',
         [
@@ -474,11 +422,6 @@ describe('test npm-setup-publish', () => {
           'email',
           'somename@example.com'
         ],
-        expect.objectContaining({cwd: repository})
-      ])
-      expect(mockExec.mock.calls[1]).toEqual([
-        'npm',
-        ['config', 'set', '--location', 'project', 'unsafe-perm', 'true'],
         expect.objectContaining({cwd: repository})
       ])
     })
@@ -513,7 +456,7 @@ describe('test npm-setup-publish', () => {
       expect(sshKeyData.toString()).toEqual(`${deployKey}\n`)
 
       const mockExec = mocked(exec)
-      expect(mockExec.mock.calls.length).toEqual(8)
+      expect(mockExec.mock.calls.length).toEqual(7)
 
       expect(mockExec.mock.calls[0]).toEqual([
         'npm',
@@ -528,24 +471,19 @@ describe('test npm-setup-publish', () => {
         expect.objectContaining({cwd: npmrcDirectory})
       ])
       expect(mockExec.mock.calls[1]).toEqual([
-        'npm',
-        ['config', 'set', '--location', 'project', 'unsafe-perm', 'true'],
-        expect.objectContaining({cwd: npmrcDirectory})
-      ])
-      expect(mockExec.mock.calls[2]).toEqual([
         'git',
         ['update-index', '--assume-unchanged', npmrcPath]
       ])
-      expect(mockExec.mock.calls[3][0]).toEqual('ssh-keyscan')
-      expect(mockExec.mock.calls[4]).toEqual([
+      expect(mockExec.mock.calls[2][0]).toEqual('ssh-keyscan')
+      expect(mockExec.mock.calls[3]).toEqual([
         'git',
         ['config', 'user.email', email]
       ])
-      expect(mockExec.mock.calls[5]).toEqual([
+      expect(mockExec.mock.calls[4]).toEqual([
         'git',
         ['config', 'user.name', username]
       ])
-      expect(mockExec.mock.calls[6]).toEqual([
+      expect(mockExec.mock.calls[5]).toEqual([
         'git',
         [
           'config',
@@ -553,7 +491,7 @@ describe('test npm-setup-publish', () => {
           expect.stringContaining('UserKnownHostsFile')
         ]
       ])
-      expect(mockExec.mock.calls[7]).toEqual([
+      expect(mockExec.mock.calls[6]).toEqual([
         'git',
         [
           'remote',

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -40,6 +40,11 @@ export async function npmSet(
   key: string,
   value: string
 ): Promise<void> {
+  if (key.match(/(^|:)always-auth$/)) {
+    core.warning('always-auth is no longer a support npmrc key')
+    return
+  }
+
   const options = {cwd}
 
   await exec.exec(

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -40,11 +40,6 @@ export async function npmSet(
   key: string,
   value: string
 ): Promise<void> {
-  if (key.match(/(^|:)always-auth$/)) {
-    core.warning('always-auth is no longer a support npmrc key')
-    return
-  }
-
   const options = {cwd}
 
   await exec.exec(
@@ -69,7 +64,14 @@ export async function updateNpmrc(
       if (match && match.groups) {
         const key = match.groups.key
         const value = match.groups.value
-        await npmSet(npmrcDirectory, key, value)
+        if (key.match(/(^|:)always-auth$/)) {
+          core.warning(
+            'always-auth is not supported by npm config set; writing it manually to the file'
+          )
+          await fs.appendFile(npmrcPath, `\n${key} = ${value}\n`)
+        } else {
+          await npmSet(npmrcDirectory, key, value)
+        }
       }
     }
   }

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -73,9 +73,6 @@ export async function updateNpmrc(
       }
     }
   }
-
-  // Is this still needed?
-  await npmSet(npmrcDirectory, 'unsafe-perm', 'true')
 }
 
 export async function setupNpmPublish(

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -41,6 +41,12 @@ export async function updateNpmRc(
   npmrcPath: string,
   contents: string | null
 ): Promise<void> {
+  const npmrcDirectory = path.dirname(path.resolve(npmrcPath))
+
+  const options: exec.ExecOptions = {
+    cwd: npmrcDirectory
+  }
+
   if (contents) {
     const lines = contents.trim().split('\n')
 
@@ -50,26 +56,21 @@ export async function updateNpmRc(
       if (match && match.groups) {
         const key = match.groups.key
         const value = match.groups.value
-        await exec.exec('npm', [
-          'config',
-          'set',
-          '--location',
-          'project',
-          key,
-          value
-        ])
+        await exec.exec(
+          'npm',
+          ['config', 'set', '--location', 'project', key, value],
+          options
+        )
       }
     }
   }
+
   // Is this still needed?
-  await exec.exec('npm', [
-    'config',
-    'set',
-    '--location',
-    'project',
-    'unsafe-perm',
-    'true'
-  ])
+  await exec.exec(
+    'npm',
+    ['config', 'set', '--location', 'project', 'unsafe-perm', 'true'],
+    options
+  )
 }
 
 export async function setupNpmPublish(


### PR DESCRIPTION
The below should not be an issue: frontend doesn't alter this file.

~Do not merge until a potential issue in the frontend repository is resolved:~

```
npm WARN ignoring workspace config at /home/sjagoe/workspace/smartly-search/frontend/packages/creative-editor/.npmrc
npm WARN config This command does not support workspaces.
```

Apparently npm can't set values in workspace .npmrc (e.g. `frontend/packages/creative-editor`).

This could impact frontend builds until that extra npmrc file is removed

https://smartlyio.slack.com/archives/C013995RB9V/p1682586077677569?thread_ts=1682082980.890289&cid=C013995RB9V