### PR TITLE
Ignore comments in npmrc when updating values

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -143,7 +143,6 @@ email = test@example.com # more comments
       await updateNpmrc(npmrcPath, newNpmrcContent)
 
       const npmrcContent = (await fs.readFile(npmrcPath)).toString()
-      console.log(npmrcContent)
       const options: Record<string, string> = {
         registry: 'https://artifactor.ee/registry',
         email: 'test@example.com'

--- a/src/setup-npm-publish.ts
+++ b/src/setup-npm-publish.ts
@@ -60,7 +60,12 @@ export async function updateNpmrc(
 
     core.info(`Updating npm configuration ${npmrcPath}`)
     for (const line of lines) {
-      const match = line.match(/^(?<key>[^=]+?)\s*=\s*(?<value>.*)$/)
+      if (line.match(/^\s*#/)) {
+        continue
+      }
+      const match = line.match(
+        /^(?<key>[^=]+?)\s*=\s*(?<value>.*?)(?<comment> #.*)?$/
+      )
       if (match && match.groups) {
         const key = match.groups.key
         const value = match.groups.value


### PR DESCRIPTION
This action would have failed on the old config in https://github.com/smartlyio/frontend/pull/19831/commits/66639864d59947ef83eb17f7918182b29cac9f32 (removed in that commit).

Fix it to handle comments by skipping them in the parsing